### PR TITLE
[DON'T MERGE] Make Store inherit IObservable

### DIFF
--- a/src/App/App.fs
+++ b/src/App/App.fs
@@ -9,10 +9,10 @@ open Sveltish.Bindings
 
 open Browser.Types
 
-let counter _ _  = Counter.Counter ()
-let helloWorld _ _ = HelloWorld.helloWorld()
+// let counter _ _  = Counter.Counter ()
+// let helloWorld _ _ = HelloWorld.helloWorld()
 
-let minion _ _ = DynamicAttributes.view()
+// let minion _ _ = DynamicAttributes.view()
 
 let make v = fun _ _ -> v()
 
@@ -29,44 +29,44 @@ type Message =
     | SetSource of string
     | TodosMsg of Todos.Message
 
-type Demo = {
-    Title : string
-    Category : string
-    Create : (Model -> (Message->unit) -> NodeFactory)
-    Sources : string list
-} with
-    static member All = [
-        { Category = "Introduction";Title = "Hello World";  Create = helloWorld ; Sources = ["HelloWorld.fs"]}
-        { Category = "Introduction";Title = "Dynamic attributes";  Create = minion ; Sources = ["DynamicAttributes.fs"]}
-        { Category = "Introduction";Title = "Styling";  Create = make StylingExample.view ; Sources = ["Styling.fs"]}
-        { Category = "Introduction";Title = "Nested components";  Create = make NestedComponents.view ; Sources = ["NestedComponents.fs"; "Nested.fs"]}
-        { Category = "Reactivity";Title = "Reactive assignments";  Create = counter ; Sources = ["Counter.fs"]}
-        { Category = "Reactivity";Title = "Reactive declarations";  Create = make ReactiveDeclarations.view ; Sources = ["ReactiveDeclarations.fs"]}
-        { Category = "Reactivity";Title = "Reactive statements";  Create = make ReactiveStatements.view ; Sources = ["ReactiveStatements.fs"]}
-        { Category = "Animations"; Title = "The animate directive"; Create = (fun m d -> Todos.view m.TodosModel (d<<TodosMsg)); Sources = ["Todos.fs"] }
-    ]
+//type Demo = {
+//    Title : string
+//    Category : string
+//    Create : (Model -> (Message->unit) -> NodeFactory)
+//    Sources : string list
+//} with
+//    static member All = [
+//        // { Category = "Introduction";Title = "Hello World";  Create = helloWorld ; Sources = ["HelloWorld.fs"]}
+//        // { Category = "Introduction";Title = "Dynamic attributes";  Create = minion ; Sources = ["DynamicAttributes.fs"]}
+//        // { Category = "Introduction";Title = "Styling";  Create = make StylingExample.view ; Sources = ["Styling.fs"]}
+//        // { Category = "Introduction";Title = "Nested components";  Create = make NestedComponents.view ; Sources = ["NestedComponents.fs"; "Nested.fs"]}
+//        // { Category = "Reactivity";Title = "Reactive assignments";  Create = counter ; Sources = ["Counter.fs"]}
+//        // { Category = "Reactivity";Title = "Reactive declarations";  Create = make ReactiveDeclarations.view ; Sources = ["ReactiveDeclarations.fs"]}
+//        // { Category = "Reactivity";Title = "Reactive statements";  Create = make ReactiveStatements.view ; Sources = ["ReactiveStatements.fs"]}
+//        { Category = "Animations"; Title = "The animate directive"; Create = (fun m d -> Todos.view m.TodosModel (d<<TodosMsg)); Sources = ["Todos.fs"] }
+//    ]
 
-let init() =
-    let todosModel = Todos.init()
-    {
-        Demo = Store.make "Hello World"
-        TodosModel = todosModel
-        Source = Store.make ""
-        Tab = Store.make "demo"
-    }
-
-let update msg model =
-    match msg with
-    | SetTab t ->
-        model.Tab <~ t
-    | SetDemo d ->
-        model.Demo <~ d
-        model.Source <~ ""
-        model.Tab <~ "demo"
-    | SetSource src ->
-        model.Source <~ src
-    | TodosMsg m ->
-        Todos.update m model.TodosModel
+//let init() =
+//    let todosModel = Todos.init()
+//    {
+//        Demo = Store.make "Hello World"
+//        TodosModel = todosModel
+//        Source = Store.make ""
+//        Tab = Store.make "demo"
+//    }
+//
+//let update msg model =
+//    match msg with
+//    | SetTab t ->
+//        model.Tab <~ t
+//    | SetDemo d ->
+//        model.Demo <~ d
+//        model.Source <~ ""
+//        model.Tab <~ "demo"
+//    | SetSource src ->
+//        model.Source <~ src
+//    | TodosMsg m ->
+//        Todos.update m model.TodosModel
 
 let mainStyleSheet = [
 
@@ -144,40 +144,40 @@ let mainStyleSheet = [
     ]
 ]
 
-let demos model dispatch =
-    Html.div [
-        class' "column app-demo"
-        for d in Demo.All do
-            d.Create model dispatch |> Bindings.show (model.Demo |%> (fun demo -> demo = d.Title))
-    ]
-
-let Section (name:string) model dispatch = [
-    Html.h5 [ class' "title is-6"; text (name.ToUpper()) ]
-    Html.ul [
-        for d in Demo.All |> List.filter (fun x -> x.Category = name) do
-            Html.li [
-                Html.a [
-                    href "#"
-                    text d.Title
-                    onClick (fun e -> e.preventDefault(); d.Title |> SetDemo |> dispatch )
-                ]
-            ]
-        ]
-    ]
+//let demos model dispatch =
+//    Html.div [
+//        class' "column app-demo"
+//        for d in Demo.All do
+//            d.Create model dispatch |> Bindings.show (model.Demo |%> (fun demo -> demo = d.Title))
+//    ]
+//
+//let Section (name:string) model dispatch = [
+//    Html.h5 [ class' "title is-6"; text (name.ToUpper()) ]
+//    Html.ul [
+//        for d in Demo.All |> List.filter (fun x -> x.Category = name) do
+//            Html.li [
+//                Html.a [
+//                    href "#"
+//                    text d.Title
+//                    onClick (fun e -> e.preventDefault(); d.Title |> SetDemo |> dispatch )
+//                ]
+//            ]
+//        ]
+//    ]
 
 let urlBase = "https://raw.githubusercontent.com/davedawkins/Fable.Sveltish/main/src/App"
 
-let findDemo name = Demo.All |> List.find (fun d -> d.Title = name)
+//let findDemo name = Demo.All |> List.find (fun d -> d.Title = name)
 
-let fetchSource  (model:Model) dispatch =
-    let src = model.Tab.Value()
-    if (src <> "" && src <> "demo") then
-        let url = sprintf "%s/%s" urlBase (model.Tab.Value())
-        printf($"URL={url}")
-        fetch url []
-        |> Promise.bind (fun res -> res.text())
-        |> Promise.map (fun txt -> txt |> SetSource |> dispatch)
-        |> ignore
+// let fetchSource  (model:Model) dispatch =
+//     let src = model.Tab.Value()
+//     if (src <> "" && src <> "demo") then
+//         let url = sprintf "%s/%s" urlBase (model.Tab.Value())
+//         printf($"URL={url}")
+//         fetch url []
+//         |> Promise.bind (fun res -> res.text())
+//         |> Promise.map (fun txt -> txt |> SetSource |> dispatch)
+//         |> ignore
 
 
 let tabItem name dispatch =
@@ -192,7 +192,7 @@ let tabItem name dispatch =
 let viewSource model dispatch =
     Html.div [
         class' "column"
-        on "sveltish-show" <| fun _ -> fetchSource model dispatch
+        // on "sveltish-show" <| fun _ -> fetchSource model dispatch
         Html.pre [
             Html.code [
                 class' "fsharp"
@@ -201,9 +201,9 @@ let viewSource model dispatch =
         ]
     ]
 
-let appMain (model:Model) (dispatch : Message -> unit) =
+let appMain () =
 
-    let currentDemo = model.Demo |> Store.map findDemo
+//    let currentDemo = model.Demo |> Store.map findDemo
 
     style mainStyleSheet <|
         Html.div [
@@ -217,35 +217,37 @@ let appMain (model:Model) (dispatch : Message -> unit) =
             Html.div [
                 class' "columns app-main-section"
 
-                Html.div <|
-                    (class' "column is-one-quarter app-contents") ::
-                    Section "Introduction" model dispatch @
-                    Section "Reactivity" model dispatch @
-                    Section "Animations" model dispatch
+//                Html.div <|
+//                    (class' "column is-one-quarter app-contents") ::
+//                    Section "Introduction" model dispatch @
+//                    Section "Reactivity" model dispatch @
+//                    Section "Animations" model dispatch
 
                 Html.div [
                     class' "column app-demo-section"
 
-                    Html.div [
-                        class' "app-toolbar"
-                        bind currentDemo (fun demo ->
-                            Html.ul [
-                                class' "app-tab"
-                                tabItem "demo" dispatch
-                                fragment (demo.Sources |> List.map (fun src -> tabItem src dispatch))
-                            ]
-                        )
-                    ]
+//                    Html.div [
+//                        class' "app-toolbar"
+//                        bind currentDemo (fun demo ->
+//                            Html.ul [
+//                                class' "app-tab"
+//                                tabItem "demo" dispatch
+//                                fragment (demo.Sources |> List.map (fun src -> tabItem src dispatch))
+//                            ]
+//                        )
+//                    ]
 
-                    transitionMatch model.Tab <| [
-                        ((fun t -> t = "demo"),  demos model dispatch,      None)
-                        ((fun t -> t <> "demo"), viewSource model dispatch, None)
-                    ]
+                    Todos.view()
+                
+//                    transitionMatch model.Tab <| [
+//                        ((fun t -> t = "demo"),  demos model dispatch,      None)
+//                        ((fun t -> t <> "demo"), viewSource model dispatch, None)
+//                    ]
                 ]
             ]
         ]
 
-let app model dispatch =
+let app() =
     Styling.app [
         // Page title
         headTitle "Sveltish"
@@ -254,7 +256,7 @@ let app model dispatch =
         headStylesheet "https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css"
 
         // Build the app
-        appMain model dispatch
+        appMain()
     ]
-
-Sveltish.Program.makeProgram "sveltish-app" init update app
+    
+app() |> Sveltish.DOM.mountElement "sveltish-app"

--- a/src/App/App.fsproj
+++ b/src/App/App.fsproj
@@ -3,16 +3,16 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="ReactiveStatements.fs" />
+    <!-- <Compile Include="ReactiveStatements.fs" />
     <Compile Include="Nested.fs" />
     <Compile Include="NestedComponents.fs" />
     <Compile Include="Styling.fs" />
     <Compile Include="ReactiveDeclarations.fs" />
     <Compile Include="DynamicAttributes.fs" />
-    <Compile Include="HelloWorld.fs" />
+    <Compile Include="HelloWorld.fs" /> -->
     <Compile Include="Todos.fs" />
-    <Compile Include="Counter.fs" />
-    <Compile Include="CounterWithTransition.fs" />
+    <!-- <Compile Include="Counter.fs" />
+    <Compile Include="CounterWithTransition.fs" /> -->
     <Compile Include="App.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Fable.Sveltish/Store.fs
+++ b/src/Fable.Sveltish/Store.fs
@@ -1,34 +1,201 @@
 namespace Sveltish
 
-type Store<'T> = {
-    Id : int
-    Value : (unit -> 'T)
-    Set   : ('T -> unit)
+open System
 
-    // Subscribe takes a callback that will be called immediately upon
-    // subscription, and when the value changes
-    // Result is an unsubscription function
-    Subscribe : ('T -> unit) -> (unit -> unit)
-}
+type Store<'Model> =
+    inherit IObservable<'Model>
+    abstract Update: f:('Model -> 'Model) -> unit
+
+// type Store<'T> = {
+//     Id : int
+//     Value : (unit -> 'T)
+//     Set   : ('T -> unit)
+
+//     // Subscribe takes a callback that will be called immediately upon
+//     // subscription, and when the value changes
+//     // Result is an unsubscription function
+//     Subscribe : ('T -> unit) -> (unit -> unit)
+// }
 
 [<RequireQualifiedAccess>]
 module Store =
+    
+    type IStore<'Model> = Store<'Model>
+    
+    
 
     open Browser.Dom
     open Browser.Event
 
+    type Update<'Model> = ('Model -> 'Model) -> unit
+    type Dispatch<'Msg> = 'Msg -> unit
+    type Cmd<'Msg> = (Dispatch<'Msg> -> unit) list
+    
+    type StoreCons<'Model, 'Store> = (unit -> 'Model) -> ('Model -> unit) -> 'Store * Update<'Model>
+
+    module internal Helpers =
+        type CmdHandler<'Msg>(handler, ?dispose) =
+            member _.Handle(cmd: Cmd<'Msg>): unit = handler cmd
+            member _.Dispose() = match dispose with Some d -> d () | None -> ()
+            interface IDisposable with
+                member this.Dispose() = this.Dispose()
+
+        let disposable f =
+            { new IDisposable with
+                member _.Dispose() = f () }
+
+    #if FABLE_COMPILER
+        open Fable.Core
+
+        [<Emit("$0 === $1")>]
+        let fastEquals (x: 'T) (y: 'T): bool = jsNative
+
+        let cmdHandler (dispatch: 'Msg -> unit): CmdHandler<'Msg> =
+            new CmdHandler<_>(List.iter (fun cmd -> JS.setTimeout (fun _ -> cmd dispatch) 0 |> ignore))
+    #else
+        let fastEquals (x: 'T) (y: 'T): bool = Unchecked.equals x y
+
+        let cmdHandler (dispatch: 'Msg -> unit): CmdHandler<'Msg> =
+            let cts = new Threading.CancellationTokenSource()
+
+            let mb = MailboxProcessor.Start(fun inbox -> async {
+                while true do
+                    let! msg = inbox.Receive()
+                    dispatch msg
+            }, cts.Token)
+
+            new CmdHandler<_>(List.iter (fun cmd -> cmd mb.Post), fun _ -> cts.Cancel())
+    #endif    
+
+    type Store<'Model>(init: unit -> 'Model, dispose: 'Model -> unit) =
+        let mutable uid = 0
+        let mutable model = Unchecked.defaultof<_>
+
+        let subscribers =
+            Collections.Generic.Dictionary<_, IObserver<'Model>>()
+
+        member _.Update(f: 'Model -> 'Model) =
+            if subscribers.Count > 0 then
+                let newModel = f model
+
+                if not (Helpers.fastEquals model newModel) then
+                    model <- newModel
+
+                    subscribers.Values
+                    |> Seq.iter (fun s -> s.OnNext(model))
+
+        member _.Subscribe(observer: IObserver<'Model>): IDisposable =
+            if subscribers.Count = 0 then model <- init ()
+            let id = uid
+            uid <- uid + 1
+            subscribers.Add(id, observer)
+            
+            // TODO: Is this the right way to report the model to the subscriber immediately?
+            Fable.Core.JS.setTimeout (fun _ -> observer.OnNext(model)) 0 |> ignore
+
+            { new IDisposable with
+                member _.Dispose() =
+                    if subscribers.Remove(id) && subscribers.Count = 0 then
+                        dispose model
+                        model <- Unchecked.defaultof<_> }
+
+        // member _.SubscribeImmediate(observer: IObserver<'Model>): 'Model * IDisposable =
+        //     if subscribers.Count = 0 then
+        //         model <- init()
+        //     let id = uid
+        //     uid <- uid + 1
+        //     subscribers.Add(id, observer)
+        //     let disposable =
+        //         { new IDisposable with
+        //             member _.Dispose() =
+        //                 if subscribers.Remove(id) && subscribers.Count = 0 then
+        //                     dispose model
+        //                     model <- Unchecked.defaultof<_> }
+        //     model, disposable
+
+        // member this.SubscribeImmediate(observer: 'Model -> unit): 'Model * IDisposable =
+        //     let observer =
+        //         { new IObserver<_> with
+        //             member _.OnNext(value) = observer value
+        //             member _.OnCompleted() = ()
+        //             member _.OnError(_error: exn) = () }
+        //     this.SubscribeImmediate(observer)
+
+        interface IStore<'Model> with
+            member this.Update(f) = this.Update(f)
+            member this.Subscribe(observer: IObserver<'Model>) = this.Subscribe(observer)
+
+    
+                
+    let makeElmishWithCons (init: 'Props -> 'Model * Cmd<'Msg>)
+                           (update: 'Msg -> 'Model -> 'Model * Cmd<'Msg>)
+                           (dispose: 'Model -> unit)
+                           (cons: StoreCons<'Model, 'Store>)
+                           : 'Props -> 'Store * Dispatch<'Msg> =
+
+        let mutable _storeDispatch: ('Store * Dispatch<'Msg>) option = None
+
+        let mutable _cmdHandler =
+            Unchecked.defaultof<Helpers.CmdHandler<'Msg>>
+
+        fun props ->
+            match _storeDispatch with
+            | Some storeDispatch -> storeDispatch
+            | None ->
+                let store, storeUpdate =
+                    cons
+                        (fun () ->
+                            let m, cmd = init props
+                            _cmdHandler.Handle cmd
+                            m)
+                        (fun m ->
+                            _cmdHandler.Dispose()
+                            dispose m)
+
+                let dispatch msg =
+                    let mutable _cmds = []
+                    storeUpdate(fun model ->
+                        let model, cmds = update msg model
+                        _cmds <- cmds
+                        model)
+                    _cmdHandler.Handle _cmds
+
+                _cmdHandler <- Helpers.cmdHandler dispatch
+                _storeDispatch <- Some(store, dispatch)
+                store, dispatch
+
+    let makeElmish (init: 'Props -> 'Model * Cmd<'Msg>)
+                   (update: 'Msg -> 'Model -> 'Model * Cmd<'Msg>)
+                   (dispose: 'Model -> unit)
+                   : 'Props -> IStore<'Model> * Dispatch<'Msg> =
+
+        makeElmishWithCons init update dispose (fun i d ->
+            let s = Store(i, d)
+            upcast s, s.Update)
+
+    let makeElmishSimple (init: 'Props -> 'Model)
+                   (update: 'Msg -> 'Model -> 'Model)
+                   (dispose: 'Model -> unit)
+                   : 'Props -> IStore<'Model> * Dispatch<'Msg> =
+
+        let init p = init p, []
+        let update msg model = update msg model, []
+        makeElmishWithCons init update dispose (fun i d ->
+            let s = Store(i, d)
+            upcast s, s.Update)
+    
     let newStoreId = CodeGeneration.makeIdGenerator()
 
     let log = Logging.log "store"
 
-    type Subscriber<'T> = {
-        Id : int
-        Set : ('T -> unit)
-    }
+    // type Subscriber<'T> = {
+    //     Id : int
+    //     Set : ('T -> unit)
+    // }
 
-    let set (store:Store<'T>) (value:'T) = store.Set value
-    let get (store:Store<'T>) = store.Value()
-    let subscribe (store:Store<'T>) f = store.Subscribe(f)
+    // let set (store:Store<'T>) (value:'T) = store.Set value
+    // let get (store:Store<'T>) = store.Value()
+    // let subscribe (store:Store<'T>) f = store.Subscribe(f)
 
     let newSubId = CodeGeneration.makeIdGenerator()
 
@@ -63,123 +230,123 @@ module Store =
             then f()
             else waiting <- f :: waiting
 
-    let makeFromGetSet<'T> (get : unit -> 'T) (set : 'T -> unit) =
-        let mutable subscribers : Subscriber<'T> list = []
-        let myId = newStoreId()
-        {
-            Id = myId
-            Value = get
-            Set  = fun (v : 'T) ->
-                startNotify()
-                set(v)
-                for s in subscribers do s.Set(get())
-                endNotify()
-            Subscribe = (fun notify ->
-                let id = newSubId()
-                let unsub = (fun () ->
-                    subscribers <- subscribers |> List.filter (fun s -> s.Id <> id)
-                )
-                subscribers <- { Id = id; Set = notify } :: subscribers
-                notify(get())
-                unsub
-            )
-        }
+    // let makeFromGetSet<'T> (get : unit -> 'T) (set : 'T -> unit) =
+    //     let mutable subscribers : Subscriber<'T> list = []
+    //     let myId = newStoreId()
+    //     {
+    //         Id = myId
+    //         Value = get
+    //         Set  = fun (v : 'T) ->
+    //             startNotify()
+    //             set(v)
+    //             for s in subscribers do s.Set(get())
+    //             endNotify()
+    //         Subscribe = (fun notify ->
+    //             let id = newSubId()
+    //             let unsub = (fun () ->
+    //                 subscribers <- subscribers |> List.filter (fun s -> s.Id <> id)
+    //             )
+    //             subscribers <- { Id = id; Set = notify } :: subscribers
+    //             notify(get())
+    //             unsub
+    //         )
+    //     }
 
-    let forceNotify (store : Store<'T>) =
-        store.Value() |> store.Set
+    // let forceNotify (store : Store<'T>) =
+    //     store.Value() |> store.Set
 
-    let make<'T> (v : 'T) =
-        // Storage is separated from Store<T> so that it doesn't leak
-        // through the abstraction.
-        let mutable value = v
-        let get'() = value
-        let set'(v) = value <- v
-        makeFromGetSet get' set'
+//     let make<'T> (v : 'T) =
+//         // Storage is separated from Store<T> so that it doesn't leak
+//         // through the abstraction.
+//         let mutable value = v
+//         let get'() = value
+//         let set'(v) = value <- v
+//         makeFromGetSet get' set'
 
-    let makeFromProperty obj name =
-        let get = Interop.getter obj name
-        let set = Interop.setter obj name
-        makeFromGetSet get set
+//     let makeFromProperty obj name =
+//         let get = Interop.getter obj name
+//         let set = Interop.setter obj name
+//         makeFromGetSet get set
 
-    let makeFromExpression<'T> (expr : (unit -> 'T)) =
-        let mutable cache : 'T = expr()
-        makeFromGetSet
-            (fun () -> cache)
+//     let makeFromExpression<'T> (expr : (unit -> 'T)) =
+//         let mutable cache : 'T = expr()
+//         makeFromGetSet
+//             (fun () -> cache)
 
-            // This setter will be called by forceNotify. We don't care about the incoming
-            // value (which will have been from our getter() anyway), and so we use
-            // this opportunity to recache the expression value.
-            //
-            // Code smell, since caller will be surprised that their supplied value was
-            // silently ignored.
-            // Ideally, the getter wants to know whether the expression has changed value
-            // since it was last cached, which can be implemented by having a notification
-            // when its dependencies have changed.
-            (fun _ -> cache <- expr())
+//             // This setter will be called by forceNotify. We don't care about the incoming
+//             // value (which will have been from our getter() anyway), and so we use
+//             // this opportunity to recache the expression value.
+//             //
+//             // Code smell, since caller will be surprised that their supplied value was
+//             // silently ignored.
+//             // Ideally, the getter wants to know whether the expression has changed value
+//             // since it was last cached, which can be implemented by having a notification
+//             // when its dependencies have changed.
+//             (fun _ -> cache <- expr())
 
-    let expr = makeFromExpression
+//     let expr = makeFromExpression
 
-    let link (fromStore : Store<'T1>) (toStore : Store<'T2>) =
-        let mutable init = false
-        fromStore.Subscribe( fun _ ->
-            if init then forceNotify toStore else init <- true
-            ) |> ignore
-        toStore
+//     let link (fromStore : Store<'T1>) (toStore : Store<'T2>) =
+//         let mutable init = false
+//         fromStore.Subscribe( fun _ ->
+//             if init then forceNotify toStore else init <- true
+//             ) |> ignore
+//         toStore
 
-    // Subscribe wants a setter (T->unit), this converts that into a notifier (unit -> unit)
-    // This allows us to know what something changed, ignoring the type and the value. It's a
-    // sign though that we intend to do a general re-evaluation to bring things back in
-    // sync, so perhaps a code smell for notifications not being as fine grained as they could be
-    let makeNotifier store = (fun callback -> store.Subscribe( fun _ -> callback() )  |> ignore)
+//     // Subscribe wants a setter (T->unit), this converts that into a notifier (unit -> unit)
+//     // This allows us to know what something changed, ignoring the type and the value. It's a
+//     // sign though that we intend to do a general re-evaluation to bring things back in
+//     // sync, so perhaps a code smell for notifications not being as fine grained as they could be
+//     let makeNotifier store = (fun callback -> store.Subscribe( fun _ -> callback() )  |> ignore)
 
-    //
-    // Map the wrapped value. For a List<T> (instead of a Store<T>) this might be
-    // called foldMap
-    //
-    let getMap f s =
-        s |> get |> f
+//     //
+//     // Map the wrapped value. For a List<T> (instead of a Store<T>) this might be
+//     // called foldMap
+//     //
+//     let getMap f s =
+//         s |> get |> f
 
-    //
-    // Map f onto s, to produce a new store. The new store will be updated whenever
-    // the source store changes
-    //
-    let map<'A,'B> (f : 'A -> 'B) (s : Store<'A>) =
-        let result = s |> getMap f |> make
-        let unsub = subscribe s (f >> (set result))
-        result
+//     //
+//     // Map f onto s, to produce a new store. The new store will be updated whenever
+//     // the source store changes
+//     //
+//     let map<'A,'B> (f : 'A -> 'B) (s : Store<'A>) =
+//         let result = s |> getMap f |> make
+//         let unsub = subscribe s (f >> (set result))
+//         result
 
-    let modify (store:Store<'T>) (f:('T -> 'T)) =
-        store |> getMap f |> set store
+//     let modify (store:Store<'T>) (f:('T -> 'T)) =
+//         store |> getMap f |> set store
 
-    // Helpers for list stores
-    let fetch pred (store:Store<List<'T>>) =
-        store |> getMap (List.tryFind pred)
+//     // Helpers for list stores
+//     let fetch pred (store:Store<List<'T>>) =
+//         store |> getMap (List.tryFind pred)
 
-    let fetchByKey kf key (store:Store<List<'T>>) =
-        let pred r = kf(r) = key
-        fetch pred store
+//     let fetchByKey kf key (store:Store<List<'T>>) =
+//         let pred r = kf(r) = key
+//         fetch pred store
 
-[<AutoOpen>]
-module StoreOperators =
-    let (|~>) a b = Store.link a b |> ignore; b
-    let (<~|) a b = Store.link a b |> ignore; a
+// [<AutoOpen>]
+// module StoreOperators =
+//     let (|~>) a b = Store.link a b |> ignore; b
+//     let (<~|) a b = Store.link a b |> ignore; a
 
-    let (|%>) s f = Store.map f s
-    let (|->) s f = Store.getMap f s
+//     let (|%>) s f = Store.map f s
+//     let (|->) s f = Store.getMap f s
 
-    let (<~) (s : Store<'T>) v =
-        Store.set s v
+//     let (<~) (s : Store<'T>) v =
+//         Store.set s v
 
-    let (<~-) (s : Store<'T>) v =
-        Store.set s v
+//     let (<~-) (s : Store<'T>) v =
+//         Store.set s v
 
-    let (-~>) v (s : Store<'T>) =
-        Store.set s v
+//     let (-~>) v (s : Store<'T>) =
+//         Store.set s v
 
-    let (<~=) store map = Store.modify store map
-    let (=~>) store map = Store.modify store map
+//     let (<~=) store map = Store.modify store map
+//     let (=~>) store map = Store.modify store map
 
-    // Study in how the expressions compose
-    //let lotsDone'Form1 = storeMap (fun x -> x |> (listCount isDone) >= 3) todos
-    //let lotsDone'Form2 = todos |>  storeMap (fun x -> x |> (listCount isDone) >= 3)
-    //let lotsDone'Form3 = todos |%>  (fun x -> x |> (listCount isDone) >= 3)
+//     // Study in how the expressions compose
+//     //let lotsDone'Form1 = storeMap (fun x -> x |> (listCount isDone) >= 3) todos
+//     //let lotsDone'Form2 = todos |>  storeMap (fun x -> x |> (listCount isDone) >= 3)
+//     //let lotsDone'Form3 = todos |%>  (fun x -> x |> (listCount isDone) >= 3)


### PR DESCRIPTION
Please don't merge: this is just an example of how we can simplify the store (to make things work I commented out most of the demo and focused on the todos). Some notes:

- I've just pasted the code for [Stores I had here](https://github.com/fable-compiler/Fable.Svelte/blob/dc20db3d63c82dc33dacef0f85d02af1f5c7736d/src/Fable.Store/Fable.Store.fs), but ideally the stores should be in a different package so the same mechanism is available to interact with different rendering libraries.
- Making the Store implement `IObservable` lets us reuse more code. For example, we can just use `Observable.map` from FSharp.Core instead of a custom `Store.map`.
- The update function for the todos is now a standard Elmish update with no mutations.