### PR TITLE
Remove inline from DOM.attr

### DIFF
--- a/src/Fable.Sveltish/DOM.fs
+++ b/src/Fable.Sveltish/DOM.fs
@@ -418,7 +418,7 @@ let addToClasslist (e:HTMLElement) classes =
 let removeFromClasslist (e:HTMLElement) classes =
     e.classList.remove( classes |> splitBySpace )
 
-let inline attr (name,value:obj) : NodeFactory = fun ctx ->
+let attr (name,value:obj) : NodeFactory = fun ctx ->
     let parent = ctx.Parent
     try
         let e = ctx.Parent :?> HTMLElement


### PR DESCRIPTION
It doesn't seem necessary to inline here. It's also better not to inline big functions because this creates code duplication and can increase the bundle size.